### PR TITLE
Added feature to restart profiler after it has been stopped.

### DIFF
--- a/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
+++ b/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
@@ -18,11 +18,6 @@ using System.Runtime.CompilerServices;
 
 
 
-
-
-
-
-
 #if DEBUG
 using ResoniteHotReloadLib;
 #endif
@@ -69,7 +64,7 @@ public class ResoniteMetricsCounterMod : ResoniteMod
     private static readonly Dictionary<MetricStage, ModConfigurationKey<bool>> stageConfigKeys = new();
     private static readonly Dictionary<MetricStage, bool> collectStage = new();
     private static bool isRunning;
-    private static Slot old_slot;
+    private static Slot? old_slot;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool GetStageConfigValue(MetricStage stage)
@@ -120,7 +115,7 @@ public class ResoniteMetricsCounterMod : ResoniteMod
         menuActionLabel = $"{MENU_ACTION} ({HotReloader.GetReloadedCountOfModType(modInstance?.GetType())})";
 #endif
 
-        DevCreateNewForm.AddAction("/Editor", menuActionLabel, Start);
+        DevCreateNewForm.AddAction("/Editor", menuActionLabel, initPanel);
     }
 #if DEBUG
 
@@ -149,19 +144,37 @@ public class ResoniteMetricsCounterMod : ResoniteMod
         return str?.Split(',')?.Select(item => item.Trim()).Where(item => item.Length > 0) ?? Enumerable.Empty<string>();
     }
 
+    public static void initPanel(Slot slot)
+    {
+        if (Panel is not null)
+        {
+           Panel.DisableStopButton();
+        }
+
+        if (old_slot is not null && isRunning is true)
+        {
+            Stop();
+        }
+
+        Start(slot);
+    }
+
     public static void Start(Slot slot = null)
     {
         if (slot == null)
         {
+            Msg("Assigning field \'old_slot\' to \'slot\' local variable");
             slot = old_slot;
             if (Panel != null)
             {
+                Msg("Disposing Panel");
                 Panel.Dispose();
                 Panel = null;
             }
         }
         else
         {
+            Msg("Assigning local variable \'slot\' to \'old_slot\' field");
             old_slot = slot;
         }
         isRunning = true;

--- a/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
+++ b/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
@@ -15,6 +15,7 @@ using System.Runtime.CompilerServices;
 
 
 #if DEBUG
+using ResoniteHotReloadLib;
 #endif
 
 namespace ResoniteMetricsCounter;
@@ -59,7 +60,7 @@ public class ResoniteMetricsCounterMod : ResoniteMod
     private static readonly Dictionary<MetricStage, ModConfigurationKey<bool>> stageConfigKeys = new();
     private static readonly Dictionary<MetricStage, bool> collectStage = new();
     public static bool isRunning { get; private set; }
-    private static Slot? old_slot;
+    private static Slot? lastUsedSlot;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool GetStageConfigValue(MetricStage stage)
@@ -118,7 +119,7 @@ public class ResoniteMetricsCounterMod : ResoniteMod
     {
         try
         {
-            SetRunning(true);//check this line, I might have gotten this true/false value wrong.
+            SetRunning(false);//check this line, I might have gotten this true/false value wrong.
             harmony.UnpatchCategory(Category.CORE);
             HotReloader.RemoveMenuOption("/Editor", menuActionLabel);
         }
@@ -146,7 +147,7 @@ public class ResoniteMetricsCounterMod : ResoniteMod
             Panel.DisableStopButton();
         }
 
-        if (old_slot is not null && isRunning is true)
+        if (lastUsedSlot is not null && isRunning is true)
         {
             SetRunning(false);
         }
@@ -159,12 +160,12 @@ public class ResoniteMetricsCounterMod : ResoniteMod
         if (slot == null)
         {
             //Msg("Assigning field \'old_slot\' to \'slot\' local variable");
-            if (old_slot == null)
+            if (lastUsedSlot == null)
             {
                 throw new ArgumentNullException(nameof(slot));
             }
-            slot = old_slot;
-            old_slot.DestroyChildren();
+            slot = lastUsedSlot;
+            lastUsedSlot.DestroyChildren();
             if (Panel != null)
             {
                 //Msg("Disposing Panel");
@@ -175,7 +176,7 @@ public class ResoniteMetricsCounterMod : ResoniteMod
         else
         {
             //Msg("Assigning local variable \'slot\' to \'old_slot\' field");
-            old_slot = slot;
+            lastUsedSlot = slot;
         }
         isRunning = true;
         Msg("Starting Profiler");

--- a/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
+++ b/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
@@ -163,14 +163,14 @@ public class ResoniteMetricsCounterMod : ResoniteMod
             {
                 throw new ArgumentNullException(nameof(slot));
             }
+            slot = old_slot;
+            old_slot.DestroyChildren();
             if (Panel != null)
             {
                 //Msg("Disposing Panel");
                 Panel.Dispose();
                 Panel = null;
             }
-            old_slot.DestroyChildren();
-            slot = old_slot;
         }
         else
         {

--- a/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
+++ b/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
@@ -163,18 +163,18 @@ public class ResoniteMetricsCounterMod : ResoniteMod
     {
         if (slot == null)
         {
-            Msg("Assigning field \'old_slot\' to \'slot\' local variable");
+            //Msg("Assigning field \'old_slot\' to \'slot\' local variable");
             slot = old_slot;
             if (Panel != null)
             {
-                Msg("Disposing Panel");
+                //Msg("Disposing Panel");
                 Panel.Dispose();
                 Panel = null;
             }
         }
         else
         {
-            Msg("Assigning local variable \'slot\' to \'old_slot\' field");
+            //Msg("Assigning local variable \'slot\' to \'old_slot\' field");
             old_slot = slot;
         }
         isRunning = true;

--- a/ResoniteMetricsCounter/UIX/MetricsPanel.cs
+++ b/ResoniteMetricsCounter/UIX/MetricsPanel.cs
@@ -26,6 +26,7 @@ internal sealed class MetricsPanel
     private readonly Slot? pagesButtonContainer;
     private readonly Slot? pagesContainer;
     private Button? stopButton;
+    private int numInspectors = 0;
 
     private Sync<string>? framesField;
     private Sync<string>? elapsedTimeField;

--- a/ResoniteMetricsCounter/UIX/MetricsPanel.cs
+++ b/ResoniteMetricsCounter/UIX/MetricsPanel.cs
@@ -94,7 +94,10 @@ internal sealed class MetricsPanel
     private static UIBuilder CreatePanel(in Slot slot, in float2 size)
     {
         slot.PersistentSelf = true;
-        slot.OnPrepareDestroy += (_) => ResoniteMetricsCounterMod.Stop();
+        slot.OnPrepareDestroy += (_) =>
+        {
+            ResoniteMetricsCounterMod.SetRunning(false);
+        };
 
         slot.Tag = "Developer";
         slot.LocalScale = float3.One * 0.00075f;
@@ -115,7 +118,7 @@ internal sealed class MetricsPanel
             {
                 page.Value.Update(metricsCounter, maxItems);
             }
-            ResoniteMetricsCounterMod.Stop();
+            ResoniteMetricsCounterMod.SetRunning(!ResoniteMetricsCounterMod.isRunning);
             //button.Enabled = false;
             button.LabelText = "Restart Profiler";
         };

--- a/ResoniteMetricsCounter/UIX/MetricsPanel.cs
+++ b/ResoniteMetricsCounter/UIX/MetricsPanel.cs
@@ -25,6 +25,7 @@ internal sealed class MetricsPanel
     private readonly int maxItems;
     private readonly Slot? pagesButtonContainer;
     private readonly Slot? pagesContainer;
+    private Button? stopButton;
 
     private Sync<string>? framesField;
     private Sync<string>? elapsedTimeField;
@@ -106,7 +107,7 @@ internal sealed class MetricsPanel
     private void BuildStopButtonUI(in UIBuilder uiBuilder)
     {
         var button = uiBuilder.Button("Stop Profiling", RadiantUI_Constants.Hero.RED);
-        //stopButton = button;
+        stopButton = button;
       
         button.LocalPressed += (_, _) =>
         {
@@ -326,5 +327,10 @@ internal sealed class MetricsPanel
     public void Dispose()
     {
         slot?.Dispose();
+    }
+
+    public void DisableStopButton()
+    {
+        stopButton.Enabled = false;
     }
 }

--- a/ResoniteMetricsCounter/UIX/MetricsPanel.cs
+++ b/ResoniteMetricsCounter/UIX/MetricsPanel.cs
@@ -106,6 +106,8 @@ internal sealed class MetricsPanel
     private void BuildStopButtonUI(in UIBuilder uiBuilder)
     {
         var button = uiBuilder.Button("Stop Profiling", RadiantUI_Constants.Hero.RED);
+        //stopButton = button;
+      
         button.LocalPressed += (_, _) =>
         {
             foreach (var page in pages)
@@ -113,7 +115,8 @@ internal sealed class MetricsPanel
                 page.Value.Update(metricsCounter, maxItems);
             }
             ResoniteMetricsCounterMod.Stop();
-            button.Enabled = false;
+            //button.Enabled = false;
+            button.LabelText = "Restart Profiler";
         };
     }
 
@@ -319,5 +322,9 @@ internal sealed class MetricsPanel
                 page.Value.Update(metricsCounter, maxItems);
             }
         }
+    }
+    public void Dispose()
+    {
+        slot?.Dispose();
     }
 }

--- a/ResoniteMetricsCounter/UIX/MetricsPanel.cs
+++ b/ResoniteMetricsCounter/UIX/MetricsPanel.cs
@@ -26,7 +26,6 @@ internal sealed class MetricsPanel
     private readonly Slot? pagesButtonContainer;
     private readonly Slot? pagesContainer;
     private Button? stopButton;
-    private int numInspectors = 0;
 
     private Sync<string>? framesField;
     private Sync<string>? elapsedTimeField;
@@ -37,6 +36,8 @@ internal sealed class MetricsPanel
     private Sync<string>? avgTotalTimeField;
     private Sync<string>? avgMaxTimeField;
     private Sync<string>? fpsField;
+
+    private static bool isProfiling = true;
 
     public MetricsPanel(Slot slot, MetricsCounter metricsCounter, in float2 size, int maxItems)
     {
@@ -97,7 +98,11 @@ internal sealed class MetricsPanel
         slot.PersistentSelf = true;
         slot.OnPrepareDestroy += (_) =>
         {
-            ResoniteMetricsCounterMod.SetRunning(false);
+            if (isProfiling)
+            {
+                ResoniteMetricsCounterMod.SetRunning(false);
+            }
+            
         };
 
         slot.Tag = "Developer";
@@ -122,6 +127,7 @@ internal sealed class MetricsPanel
             ResoniteMetricsCounterMod.SetRunning(!ResoniteMetricsCounterMod.isRunning);
             //button.Enabled = false;
             button.LabelText = "Restart Profiler";
+            isProfiling = false;
         };
     }
 


### PR DESCRIPTION
To address #17, I changed it so that the "stop profiling" button changes to a "restart profiling" button after it is pressed.

This is done by saving the slot reference and using it to rerun the initialization script when the user presses the button for a second time. In order to avoid conflicts, some extra disposal code has been added to the panel initializer. 

Effectively, this just deletes everything and re-creates it when the user presses the "restart profiler" button. While not the most elegant way of handling this functionality, it is a handy shortcut for deleting the profiler and spawning another in, which is all it needs to be.

*This PR is not quite ready yet. I still have to fix a crash that happens when opening two profilers and trying to profile at the same time*