### PR TITLE
Fix method naming for panel init

### DIFF
--- a/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
+++ b/ResoniteMetricsCounter/ResoniteMetricsCounterMod.cs
@@ -119,7 +119,7 @@ public class ResoniteMetricsCounterMod : ResoniteMod
         menuActionLabel = $"{MENU_ACTION} ({HotReloader.GetReloadedCountOfModType(modInstance?.GetType())})";
 #endif
 
-        DevCreateNewForm.AddAction("/Editor", menuActionLabel, initPanel);
+        DevCreateNewForm.AddAction("/Editor", menuActionLabel, InitPanel);
     }
 #if DEBUG
 
@@ -148,7 +148,7 @@ public class ResoniteMetricsCounterMod : ResoniteMod
         return str?.Split(',')?.Select(item => item.Trim()).Where(item => item.Length > 0) ?? Enumerable.Empty<string>();
     }
 
-    public static void initPanel(Slot slot)
+    public static void InitPanel(Slot slot)
     {
         if (Panel is not null)
         {


### PR DESCRIPTION
## Summary
- rename `initPanel` to `InitPanel`
- update editor menu registration to call `InitPanel`

## Testing
- `dotnet build ResoniteMetricsCounter/ResoniteMetricsCounter.csproj -c Release` *(fails: missing Resonite dependencies)*