### PR TITLE
Fix profiling state toggle

### DIFF
--- a/ResoniteMetricsCounter/UIX/MetricsPanel.cs
+++ b/ResoniteMetricsCounter/UIX/MetricsPanel.cs
@@ -126,9 +126,9 @@ internal sealed class MetricsPanel
                 page.Value.Update(metricsCounter, maxItems);
             }
             ResoniteMetricsCounterMod.SetRunning(!ResoniteMetricsCounterMod.isRunning);
+            isProfiling = !isProfiling;
             //button.Enabled = false;
             button.LabelText = "Restart Profiler";
-            isProfiling = false;
         };
     }
 


### PR DESCRIPTION
## Summary
- toggle isProfiling state whenever the stop button is pressed
- keep profiling off when the panel closes, even after restarting

## Testing
- `dotnet build ResoniteMetricsCounter/ResoniteMetricsCounter.csproj -warnaserror` *(fails: missing dependencies)*