### PR TITLE
Rename RefreshStep patch file

### DIFF
--- a/ResoniteMetricsCounter/Patch/World_RefreshStep_Patch.cs
+++ b/ResoniteMetricsCounter/Patch/World_RefreshStep_Patch.cs
@@ -7,7 +7,7 @@ namespace ResoniteMetricsCounter.Patch;
 
 [HarmonyPatch(typeof(World), "RefreshStep")]
 [HarmonyPatchCategory(Category.PROFILER)]
-internal static class World_RefleshStep_Patch
+internal static class World_RefreshStep_Patch
 {
     public static void Postfix(World __instance)
     {


### PR DESCRIPTION
## Summary
- rename typo `Reflesh` to `Refresh`
- update class declaration accordingly

## Testing
- `dotnet build ResoniteMetricsCounter.sln -c Release` *(fails: missing assemblies)*