### PR TITLE
Fix field name typo

### DIFF
--- a/ResoniteMetricsCounter/Utils/WorldElementHelper.cs
+++ b/ResoniteMetricsCounter/Utils/WorldElementHelper.cs
@@ -40,7 +40,7 @@ internal static class WorldElementHelper
 
     private static readonly CachedElementName nameCache = new();
     private static readonly CachedElementSlot slotCache = new();
-    private static readonly CachedGetMetricObjectRoot getMetricObjectRooCachet = new();
+    private static readonly CachedGetMetricObjectRoot getMetricObjectRootCache = new();
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -56,13 +56,13 @@ internal static class WorldElementHelper
 
     public static Slot? GetMetricObjectRoot(this IWorldElement element)
     {
-        return getMetricObjectRooCachet.GetOrCache(element);
+        return getMetricObjectRootCache.GetOrCache(element);
     }
 
     public static void Clear()
     {
         nameCache.Clear();
         slotCache.Clear();
-        getMetricObjectRooCachet.Clear();
+        getMetricObjectRootCache.Clear();
     }
 }


### PR DESCRIPTION
## Summary
- rename `getMetricObjectRooCachet` to `getMetricObjectRootCache`

## Testing
- `dotnet build` *(fails: could not find referenced packages)*