### PR TITLE
Fix Read method to throw NotSupportedException

### DIFF
--- a/ResoniteMetricsCounter/Serialization/IWorldElementConverter.cs
+++ b/ResoniteMetricsCounter/Serialization/IWorldElementConverter.cs
@@ -20,7 +20,7 @@ internal sealed class IWorldElementConverter : JsonConverter<IWorldElement>
         JsonSerializerOptions options
     )
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException("Deserialization is not supported.");
     }
 
     private static void WriteElement(Utf8JsonWriter writer, IWorldElement value)


### PR DESCRIPTION
## Summary
- replace `NotImplementedException` with `NotSupportedException` in `IWorldElementConverter.Read`
- keep code formatted via CSharpier

## Testing
- `dotnet dotnet-csharpier .` *(fails: command not found)*
- `dotnet csharpier format .`
- `dotnet csharpier check .`
- `dotnet test`