### PR TITLE
Remove unused DEFAULTSEPARATION constant

### DIFF
--- a/ResoniteMetricsCounter/UIX/MetricsPanel.cs
+++ b/ResoniteMetricsCounter/UIX/MetricsPanel.cs
@@ -19,7 +19,6 @@ internal sealed class MetricsPanel
 
     public const float DEFAULTITEMSIZE = 32;
     public const float PADDING = 4;
-    public const float DEFAULTSEPARATION = 0.1f;
 
     private readonly MetricsCounter metricsCounter;
     private readonly Slot slot;


### PR DESCRIPTION
## Summary
- delete the unused `DEFAULTSEPARATION` constant from `MetricsPanel`

## Testing
- `dotnet dotnet-csharpier .` *(fails: command not found)*
- `dotnet csharpier format .`
- `dotnet csharpier check .`
